### PR TITLE
Db Connection implementation: handle_execute + prepare + bind

### DIFF
--- a/lib/exqlite/query.ex
+++ b/lib/exqlite/query.ex
@@ -1,0 +1,55 @@
+defmodule Exqlite.Query do
+  @moduledoc """
+  Query struct returned from a successfully prepared query.
+  """
+  @type t :: %__MODULE__{
+          statement: iodata(),
+          ref: reference() | nil
+        }
+
+  defstruct statement: nil,
+            ref: nil
+
+  defimpl DBConnection.Query do
+    def parse(query, _opts) do
+      query
+    end
+
+    def describe(query, _opts) do
+      query
+    end
+
+    def encode(%{ref: nil} = query, _params, _opts) do
+      raise ArgumentError, "query #{inspect(query)} has not been prepared"
+    end
+
+    def encode(%{num_params: nil} = query, _params, _opts) do
+      raise ArgumentError, "query #{inspect(query)} has not been prepared"
+    end
+
+    def encode(%{num_params: num_params} = query, params, _opts)
+        when num_params != length(params) do
+      message =
+        "expected params count: #{inspect(num_params)}, got values: #{inspect(params)}" <>
+          " for query: #{inspect(query)}"
+
+      raise ArgumentError, message
+    end
+
+    def encode(_query, params, _opts) do
+      # TODO. See also Connection.bind/3
+      params
+      #Protocol.encode_params(params)
+    end
+
+    def decode(_query, result, _opts) do
+      result
+    end
+  end
+
+  defimpl String.Chars do
+    def to_string(%{statement: statement}) do
+      IO.iodata_to_binary(statement)
+    end
+  end
+end

--- a/lib/exqlite/result.ex
+++ b/lib/exqlite/result.ex
@@ -6,5 +6,5 @@ defmodule Exqlite.Result do
           num_rows: integer
         }
 
-  defstruct command: nil, columns: nil, rows: nil, num_rows: nil
+  defstruct command: nil, columns: [], rows: [], num_rows: 0
 end


### PR DESCRIPTION
This builds on #2.

Relevant commits: 

- 1242c1e `handle_execute` implementation. Includes prepare and bind
- 404ce4d and 99f4f09 are minor code fixes to handle this


Note: everything is as barebones as possible, just to check that everything is working. So, no funny majick around bind, for example :) See inline comments for TODOs