### PR TITLE
Connection.handle_close/3

### DIFF
--- a/lib/exqlite/sqlite3.ex
+++ b/lib/exqlite/sqlite3.ex
@@ -69,6 +69,9 @@ defmodule Exqlite.Sqlite3 do
     Sqlite3NIF.bind(conn, statement, Enum.map(args, &convert/1))
   end
 
+  @spec finalize(db(), statement()) :: :ok | {:error, reason()}
+  def finalize(conn, statement), do: Sqlite3NIF.finalize(conn, statement)
+
   @spec columns(db(), statement()) :: {:ok, []} | {:error, reason()}
   def columns(conn, statement), do: Sqlite3NIF.columns(conn, statement)
 

--- a/lib/exqlite/sqlite3_nif.ex
+++ b/lib/exqlite/sqlite3_nif.ex
@@ -37,6 +37,9 @@ defmodule Exqlite.Sqlite3NIF do
   @spec step(db(), statement()) :: :done | :busy | {:row, []}
   def step(_conn, _statement), do: :erlang.nif_error(:not_loaded)
 
+  @spec finalize(db(), statement()) :: :ok | {:error, any()}
+  def finalize(_conn, _statement), do: :erlang.nif_error(:not_loaded)
+
   @spec columns(db(), statement()) :: {:ok, []} | {:error, reason()}
   def columns(_conn, _statement), do: :erlang.nif_error(:not_loaded)
 


### PR DESCRIPTION
My C-foo is non-existent, so here's what happens (I have `Connection.test/0` as a quick-and-dirty way to test things):

- Run `Connection.test()`, and everything is fine
- Run `Connection.test()` a second time, and:

```
beam.smp(43501,0x7000048e0000) malloc: Non-aligned pointer 0x7fe3598ebc50 being freed (2)
``` 

@warmwaffles 