### PR TITLE
fix delete specifying table qualifier

### DIFF
--- a/lib/ecto/adapters/exqlite/connection.ex
+++ b/lib/ecto/adapters/exqlite/connection.ex
@@ -174,7 +174,7 @@ defmodule Ecto.Adapters.Exqlite.Connection do
     from = from(query, sources)
     where = where(query, sources)
 
-    [cte, "DELETE ", name, ".*", from, where]
+    [cte, "DELETE", from, where]
   end
 
   @impl true

--- a/test/ecto/adapters/exqlite/connection_test.exs
+++ b/test/ecto/adapters/exqlite/connection_test.exs
@@ -326,7 +326,7 @@ defmodule Ecto.Adapters.Exqlite.ConnectionTest do
              """
              WITH target_rows AS \
              (SELECT s0.id AS id FROM schema AS s0 ORDER BY s0.id LIMIT 10) \
-             DELETE s0.* \
+             DELETE \
              FROM schema AS s0\
              """
   end
@@ -1309,14 +1309,14 @@ defmodule Ecto.Adapters.Exqlite.ConnectionTest do
       |> Ecto.Queryable.to_query()
       |> plan()
 
-    assert delete_all(query) == ~s{DELETE s0.* FROM schema AS s0}
+    assert delete_all(query) == ~s{DELETE FROM schema AS s0}
 
     query =
       (e in Schema)
       |> from(where: e.x == 123)
       |> plan()
 
-    assert delete_all(query) == ~s{DELETE s0.* FROM schema AS s0 WHERE (s0.x = 123)}
+    assert delete_all(query) == ~s{DELETE FROM schema AS s0 WHERE (s0.x = 123)}
 
     assert_raise(
       ArgumentError,
@@ -1334,7 +1334,7 @@ defmodule Ecto.Adapters.Exqlite.ConnectionTest do
       |> Map.put(:prefix, "prefix")
       |> plan()
 
-    assert delete_all(query) == ~s{DELETE s0.* FROM prefix.schema AS s0}
+    assert delete_all(query) == ~s{DELETE FROM prefix.schema AS s0}
 
     query =
       Schema
@@ -1342,7 +1342,7 @@ defmodule Ecto.Adapters.Exqlite.ConnectionTest do
       |> Map.put(:prefix, "prefix")
       |> plan()
 
-    assert delete_all(query) == ~s{DELETE s0.* FROM first.schema AS s0}
+    assert delete_all(query) == ~s{DELETE FROM first.schema AS s0}
   end
 
   ##


### PR DESCRIPTION
https://sqlite.org/lang_delete.html

I began an attempt to integrate your ecto driver into `ecto_sql`, partly to make it easier to leverage their integration tests, and partly because that is probably where we may want it to be long term.
https://github.com/kevinlang/ecto_sql/tree/exqlite

I'm curious of your thoughts on that approach. :thought_balloon: 

Ran into this when trying to run a couple of the integration tests. Looks like this approach will help us find a bunch of bugs.

Most of the tests are currently failing (in that `ecto_sql` repo), but I think that is probably due to various sandbox-related bugs, and because I am not excluding a bunch of things that SQLite cannot support. 