### PR TITLE
handle :transaction mode used by SQL.Sandbox

### DIFF
--- a/lib/exqlite/connection.ex
+++ b/lib/exqlite/connection.ex
@@ -187,6 +187,9 @@ defmodule Exqlite.Connection do
       :deferred when transaction_status == :idle ->
         handle_transaction(:begin, "BEGIN TRANSACTION", state)
 
+      :transaction when transaction_status == :idle ->
+        handle_transaction(:begin, "BEGIN TRANSACTION", state)
+
       :immediate when transaction_status == :idle ->
         handle_transaction(:begin, "BEGIN IMMEDIATE TRANSACTION", state)
 
@@ -207,7 +210,7 @@ defmodule Exqlite.Connection do
         handle_transaction(:commit, "RELEASE SAVEPOINT exqlite_savepoint", state)
 
       mode
-      when mode in [:deferred, :immediate, :exclusive] and
+      when mode in [:deferred, :immediate, :exclusive, :transaction] and
              transaction_status == :transaction ->
         handle_transaction(:commit, "COMMIT", state)
     end
@@ -227,7 +230,7 @@ defmodule Exqlite.Connection do
         end
 
       mode
-      when mode in [:deferred, :immediate, :exclusive] and
+      when mode in [:deferred, :immediate, :exclusive, :transaction] and
              transaction_status == :transaction ->
         handle_transaction(:rollback, "ROLLBACK TRANSACTION", state)
     end


### PR DESCRIPTION
The SQL.Sandbox that ecto_sql uses passes along this mode for checkin/checkout. See `lib/ecto/adapters/sql/sandbox.ex` in `ecto_sql`. 

Not sure if this is the correct approach though, but it fixed my problem for now.