### PR TITLE
include state in error tuple

### DIFF
--- a/lib/exqlite/connection.ex
+++ b/lib/exqlite/connection.ex
@@ -406,7 +406,7 @@ defmodule Exqlite.Connection do
           {:ok, query, state}
         else
           {:error, reason} ->
-            {:error, %Error{message: reason}}
+            {:error, %Error{message: reason}, state}
         end
 
       {:ok, cached_query} ->
@@ -431,7 +431,7 @@ defmodule Exqlite.Connection do
         {:ok, %{query | ref: ref}, state}
 
       {:error, reason} ->
-        {:error, %Error{message: reason}}
+        {:error, %Error{message: reason}, state}
     end
   end
 
@@ -463,7 +463,7 @@ defmodule Exqlite.Connection do
       }
     else
       {:error, reason} ->
-        {:error, %Error{message: reason}}
+        {:error, %Error{message: reason}, state}
     end
   end
 
@@ -478,7 +478,7 @@ defmodule Exqlite.Connection do
     #      https://www.sqlite.org/c3ref/bind_parameter_index.html
     case Sqlite3.bind(state.db, ref, params) do
       :ok -> {:ok, query, state}
-      {:error, reason} -> {:error, %Error{message: reason}}
+      {:error, reason} -> {:error, %Error{message: reason}, state}
     end
   end
 
@@ -502,7 +502,7 @@ defmodule Exqlite.Connection do
         end
 
       {:error, reason} ->
-        {:error, %Error{message: reason}}
+        {:error, %Error{message: reason}, state}
     end
   end
 end

--- a/test/exqlite/connection_test.exs
+++ b/test/exqlite/connection_test.exs
@@ -102,7 +102,7 @@ defmodule Exqlite.ConnectionTest do
     test "users table does not exist" do
       {:ok, conn} = Connection.connect(database: :memory)
 
-      {:error, error} =
+      {:error, error, _state} =
         %Query{statement: "select * from users where id < ?"}
         |> Connection.handle_prepare([], conn)
 


### PR DESCRIPTION
A couple of `db_connection` callbacks require `state` to be returned in the tuple.