### PR TITLE
fix missing lock_for_migrations callback, add solution to database is locked

### DIFF
--- a/lib/ecto/adapters/exqlite.ex
+++ b/lib/ecto/adapters/exqlite.ex
@@ -39,6 +39,11 @@ defmodule Ecto.Adapters.Exqlite do
   @impl true
   def supports_ddl_transaction?(), do: false
 
+  @impl true
+  def lock_for_migrations(_meta, _opts, fun) do
+    fun.()
+  end
+
   @impl Ecto.Adapter.Structure
   def structure_dump(default, config) do
     path = config[:dump_path] || Path.join(default, "structure.sql")

--- a/lib/ecto/adapters/exqlite/connection.ex
+++ b/lib/ecto/adapters/exqlite/connection.ex
@@ -13,10 +13,29 @@ defmodule Ecto.Adapters.Exqlite.Connection do
   import Ecto.Adapters.Exqlite.DataType
 
   @parent_as __MODULE__
+  @connect_buffer 50
+
+  def sleep(opts) do
+    :timer.sleep(:rand.uniform(@connect_buffer))
+    opts
+  end
+
+  defp default_opts(opts) do
+    # todo: we may want to consider wrapping any provided :configure
+    # with our custom connection buffering logic
+    opts
+    |> Keyword.put_new(:configure, {__MODULE__, :sleep, []})
+  end
+
+  def start_link(opts) do
+    opts = default_opts(opts)
+    DBConnection.start_link(Exqlite.Connection, opts)
+  end
 
   @impl true
   def child_spec(options) do
     {:ok, _} = Application.ensure_all_started(:db_connection)
+    options = default_opts(options)
     DBConnection.child_spec(Exqlite.Connection, options)
   end
 


### PR DESCRIPTION
In `db_connection` I noticed that `pool_size` number of connections are started immediately and simultaneously (all within ~1ms), and that is what is causing our "db is locked" issue.

As far as I know, most db drivers in other languages use the `pool_size` as the "maximum number of open connections", and does not open them until needed, and later closes them when not needed. Which is why we don't hit this issue in the Go driver, for example.

Here is a pass at a solution, where we "buffer" the simultaneous connections by spreading them over a 50ms interval. With this added I no longer hit issues with a pool size of 10.  In the future we could be more intelligent and have the buffer interval be a function of the pool size, and so on, but this should work for now.

I'm open to other ideas on this front :). We could alternatively put similar code into the exqlite `connect` functionality, or modify `db_connection` to not be so greedy with immediately opening connections.