### PR TITLE
enable sandboxing for tests

### DIFF
--- a/lib/exqlite/connection.ex
+++ b/lib/exqlite/connection.ex
@@ -230,8 +230,8 @@ defmodule Exqlite.Connection do
         end
 
       mode
-      when mode in [:deferred, :immediate, :exclusive, :transaction] and
-             transaction_status == :transaction ->
+      when mode in [:deferred, :immediate, :exclusive, :transaction] -> #and
+             #transaction_status == :transaction ->
         handle_transaction(:rollback, "ROLLBACK TRANSACTION", state)
     end
   end

--- a/lib/exqlite/connection.ex
+++ b/lib/exqlite/connection.ex
@@ -230,8 +230,7 @@ defmodule Exqlite.Connection do
         end
 
       mode
-      when mode in [:deferred, :immediate, :exclusive, :transaction] -> #and
-             #transaction_status == :transaction ->
+      when mode in [:deferred, :immediate, :exclusive, :transaction] -> 
         handle_transaction(:rollback, "ROLLBACK TRANSACTION", state)
     end
   end

--- a/test/ecto/integration/streaming_test.exs
+++ b/test/ecto/integration/streaming_test.exs
@@ -1,5 +1,5 @@
 defmodule Ecto.Integration.StreamingTest do
-  use ExUnit.Case
+  use Ecto.Integration.Case
 
   alias Ecto.Integration.TestRepo
   alias Exqlite.Integration.User

--- a/test/ecto/integration/timestamps_test.exs
+++ b/test/ecto/integration/timestamps_test.exs
@@ -1,5 +1,5 @@
 defmodule Ecto.Integration.TimestampsTest do
-  use ExUnit.Case
+  use Ecto.Integration.Case
 
   alias Ecto.Integration.TestRepo
 

--- a/test/test_helper.exs
+++ b/test/test_helper.exs
@@ -7,36 +7,38 @@ Application.put_env(:ecto, :async_integration_tests, false)
 ecto = Mix.Project.deps_paths()[:ecto]
 Code.require_file("#{ecto}/integration_test/support/schemas.exs", __DIR__)
 
-Application.put_env(:exqlite, Ecto.Integration.TestRepo,
+alias Ecto.Integration.TestRepo
+
+Application.put_env(:exqlite, TestRepo,
   adapter: Ecto.Adapters.Exqlite,
   database: "/tmp/exqlite_sandbox_test.db",
   journal_mode: :wal,
   cache_size: -64000,
   temp_store: :memory,
-  pool_size: 1,
+  pool: Ecto.Adapters.SQL.Sandbox,
+  pool_size: 5,
   show_sensitive_data_on_connection_error: true
 )
 
-{:ok, _} =
-  Ecto.Adapters.Exqlite.ensure_all_started(
-    Ecto.Integration.TestRepo.config(),
-    :temporary
-  )
+defmodule Ecto.Integration.Case do
+  use ExUnit.CaseTemplate
+
+  setup do
+    :ok = Ecto.Adapters.SQL.Sandbox.checkout(TestRepo)
+    #on_exit(fn -> Ecto.Adapters.SQL.Sandbox.checkin(TestRepo) end)
+  end
+end
+
+{:ok, _} = Ecto.Adapters.Exqlite.ensure_all_started(TestRepo.config(), :temporary)
 
 # Load up the repository, start it, and run migrations
-_ = Ecto.Adapters.Exqlite.storage_down(Ecto.Integration.TestRepo.config())
-:ok = Ecto.Adapters.Exqlite.storage_up(Ecto.Integration.TestRepo.config())
+_ = Ecto.Adapters.Exqlite.storage_down(TestRepo.config())
+:ok = Ecto.Adapters.Exqlite.storage_up(TestRepo.config())
 
-{:ok, _} = Ecto.Integration.TestRepo.start_link()
+{:ok, _} = TestRepo.start_link()
 
-:ok =
-  Ecto.Migrator.up(
-    Ecto.Integration.TestRepo,
-    0,
-    Exqlite.Integration.Migration,
-    log: false
-  )
-
+:ok = Ecto.Migrator.up(TestRepo, 0, Exqlite.Integration.Migration, log: false)
+Ecto.Adapters.SQL.Sandbox.mode(TestRepo, :manual)
 Process.flag(:trap_exit, true)
 
 ExUnit.start()


### PR DESCRIPTION
I ran `mix test` a bunch locally to make sure there are no intermittent failures, and did not hit any (but no guarantees).

I hit an issue with rollback that was fixed by commenting out some extra conditions in a case, as you can see. Obviously not the long term fix, so feel free to adjust accordingly. Some issue with nested transactions, maybe.