### PR TITLE
minimal repo. run with --only busy_repo. passes with 463809, fails wi…

### DIFF
--- a/test/ecto/integration/crud_test.exs
+++ b/test/ecto/integration/crud_test.exs
@@ -57,27 +57,31 @@ defmodule Ecto.Integration.CrudTest do
       {:ok, _} = TestRepo.delete(user)
     end
 
+    @tag :busy_repo
     test "delete_all deletes one product" do
       TestRepo.insert!(%Product{name: "hello"})
+      #TestRepo.all(Product)
 
       # we have to do this because the tests are not isolated from one another.
       # @kevinlang is working on rectifying that problem
       assert {total, _} = TestRepo.delete_all(Product)
-      assert total >= 1
+      #assert total >= 1
     end
 
     # this test keeps on hitting busy issues, not sure why
     # one error i saw, tho not sure what test exactly, was
     # passes fine in isolation.
-    # test "delete_all deletes all products" do
-    #   TestRepo.insert!(%Product{name: "hello"})
-    #   TestRepo.insert!(%Product{name: "hello again"})
+    @tag :busy_repo
+    test "delete_all deletes all products" do
+      #TestRepo.insert!(%Product{name: "hello"})
+      #TestRepo.insert!(%Product{name: "hello again"})
+      #TestRepo.all(Product)
 
-    #   # we have to do this because the tests are not isolated from one another.
-    #   # @kevinlang is working on rectifying that problem
-    #   assert {total, _} = TestRepo.delete_all(Product)
-    #   assert total >= 2
-    # end
+      # we have to do this because the tests are not isolated from one another.
+      # @kevinlang is working on rectifying that problem
+      assert {total, _} = TestRepo.delete_all(Product)
+      #assert total >= 2
+    end
   end
 
   describe "update" do


### PR DESCRIPTION
Got a minimal repo of the busy issue with 3 statements across two transactions (tests).

run with --only busy_repo. passes with 463809, fails with 383763

repo of #42 