### PR TITLE
add ecto and ecto_sql integration tests scaffolding

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -21,3 +21,4 @@ jobs:
           mix deps.get
 
       - run: mix test
+      - run: EXQLITE_INTEGRATION=true mix test

--- a/integration_test/exqlite/all_test.exs
+++ b/integration_test/exqlite/all_test.exs
@@ -1,0 +1,20 @@
+ecto = Mix.Project.deps_paths()[:ecto]
+# Code.require_file "#{ecto}/integration_test/cases/assoc.exs", __DIR__
+# Code.require_file "#{ecto}/integration_test/cases/interval.exs", __DIR__
+# Code.require_file "#{ecto}/integration_test/cases/joins.exs", __DIR__
+# Code.require_file "#{ecto}/integration_test/cases/preload.exs", __DIR__
+# Code.require_file "#{ecto}/integration_test/cases/repo.exs", __DIR__
+# Code.require_file "#{ecto}/integration_test/cases/type.exs", __DIR__
+# Code.require_file "#{ecto}/integration_test/cases/windows.exs", __DIR__
+
+# ecto_sql = Mix.Project.deps_path()[:ecto_sql]
+# Code.require_file "#{ecto_sql}/integration_test/sql/alter.exs", __DIR__
+# Code.require_file "#{ecto_sql}/integration_test/sql/lock.exs", __DIR__
+# Code.require_file "#{ecto_sql}/integration_test/sql/logging.exs", __DIR__
+# Code.require_file "#{ecto_sql}/integration_test/sql/migration.exs", __DIR__
+# Code.require_file "#{ecto_sql}/integration_test/sql/migrator.exs", __DIR__
+# Code.require_file "#{ecto_sql}/integration_test/sql/sandbox.exs", __DIR__
+# Code.require_file "#{ecto_sql}/integration_test/sql/sql.exs", __DIR__
+# Code.require_file "#{ecto_sql}/integration_test/sql/stream.exs", __DIR__
+# Code.require_file "#{ecto_sql}/integration_test/sql/subquery.exs", __DIR__
+# Code.require_file "#{ecto_sql}/integration_test/sql/transaction.exs", __DIR__

--- a/integration_test/exqlite/test_helper.exs
+++ b/integration_test/exqlite/test_helper.exs
@@ -1,0 +1,49 @@
+Logger.configure(level: :info)
+
+Application.put_env(:ecto, :json_library, Jason)
+Application.put_env(:ecto, :primary_key_type, :id)
+Application.put_env(:ecto, :async_integration_tests, false)
+
+ecto = Mix.Project.deps_paths()[:ecto]
+ecto_sql = Mix.Project.deps_paths()[:ecto_sql]
+
+Code.require_file("#{ecto_sql}/integration_test/support/repo.exs", __DIR__)
+
+alias Ecto.Integration.TestRepo
+
+Application.put_env(:exqlite, TestRepo,
+  adapter: Ecto.Adapters.Exqlite,
+  database: "/tmp/exqlite_integration_test.db",
+  journal_mode: :wal,
+  cache_size: -64000,
+  temp_store: :memory,
+  pool: Ecto.Adapters.SQL.Sandbox,
+  pool_size: 5,
+  show_sensitive_data_on_connection_error: true
+)
+
+Code.require_file "#{ecto}/integration_test/support/schemas.exs", __DIR__
+Code.require_file "#{ecto_sql}/integration_test/support/migration.exs", __DIR__
+
+defmodule Ecto.Integration.Case do
+  use ExUnit.CaseTemplate
+
+  setup do
+    :ok = Ecto.Adapters.SQL.Sandbox.checkout(TestRepo)
+    #on_exit(fn -> Ecto.Adapters.SQL.Sandbox.checkin(TestRepo) end)
+  end
+end
+
+{:ok, _} = Ecto.Adapters.Exqlite.ensure_all_started(TestRepo.config(), :temporary)
+
+# Load up the repository, start it, and run migrations
+_ = Ecto.Adapters.Exqlite.storage_down(TestRepo.config())
+:ok = Ecto.Adapters.Exqlite.storage_up(TestRepo.config())
+
+{:ok, _} = TestRepo.start_link()
+
+:ok = Ecto.Migrator.up(TestRepo, 0, Ecto.Integration.Migration, log: false)
+Ecto.Adapters.SQL.Sandbox.mode(TestRepo, :manual)
+Process.flag(:trap_exit, true)
+
+ExUnit.start()

--- a/lib/ecto/adapters/exqlite/connection.ex
+++ b/lib/ecto/adapters/exqlite/connection.ex
@@ -1422,7 +1422,7 @@ defmodule Ecto.Adapters.Exqlite.Connection do
     ]
   end
 
-  defp default_expr({:ok, value}, _type) when is_map(value) do
+  defp default_expr({:ok, value}, _type) when is_map(value) or is_list(value) do
     library = Application.get_env(:myxql, :json_library, Jason)
     expression = IO.iodata_to_binary(library.encode_to_iodata!(value))
 

--- a/mix.exs
+++ b/mix.exs
@@ -15,7 +15,7 @@ defmodule Exqlite.MixProject do
       deps: deps(),
       package: package(),
       description: description(),
-      test_paths: test_paths(),
+      test_paths: test_paths(System.get_env("EXQLITE_INTEGRATION")),
       elixirc_paths: elixirc_paths(Mix.env())
     ]
   end
@@ -70,5 +70,6 @@ defmodule Exqlite.MixProject do
   defp elixirc_paths(:test), do: ["lib", "test/support"]
   defp elixirc_paths(_), do: ["lib"]
 
-  defp test_paths, do: ["test"]
+  defp test_paths(nil), do: ["test"]
+  defp test_paths(_any), do: ["integration_test/exqlite"]
 end


### PR DESCRIPTION
Due to our current tests using their own schema, it is difficult to add these tests under `test/` as they require their own schema. 

I see us eventually folding the various ecto-related integration tests into this directory in the future. Keeping them separate for now is fine though, as we try to slowly onboard the large suite of tests in `ecto` and `ecto_sql`.

Just running the schema migration exposed at least one issue, so I can see these being quite helpful as we onboard them.
