### PR TITLE
fix to_constraints not covering unique one

### DIFF
--- a/integration_test/exqlite/all_test.exs
+++ b/integration_test/exqlite/all_test.exs
@@ -1,5 +1,9 @@
 ecto = Mix.Project.deps_paths()[:ecto]
+
+# currently _slowly_ onboarding this one - kcl
 # Code.require_file "#{ecto}/integration_test/cases/assoc.exs", __DIR__
+
+
 # Code.require_file "#{ecto}/integration_test/cases/interval.exs", __DIR__
 # Code.require_file "#{ecto}/integration_test/cases/joins.exs", __DIR__
 # Code.require_file "#{ecto}/integration_test/cases/preload.exs", __DIR__


### PR DESCRIPTION
You can see it in action by uncommenting the `assoc.exs` test and running:

```
EXQLITE_INTEGRATION=true mix test --only unique_constraint
```

(before this change, that would result in a failure).

What would be nice is to have the SQLITE code always returned from the NIF. We would convert the `rc` into an appropriate atom. In this case we would expect a `code: :sqlite_constraint_unique` in the `Exqlite.Error` struct. That would help with other `to_constraints` too.

https://sqlite.org/rescode.html

Easiest way to enumerate is to copy and modify the `sqlite3ErrName` func in `sqlite3.c` :) 

I could not find a way to get the underlying constraint returned, though, hence my hack. Surely there must be some way? Let me know if you find anything