### PR TITLE
Handle decimals

### DIFF
--- a/lib/ecto/adapters/exqlite/codec.ex
+++ b/lib/ecto/adapters/exqlite/codec.ex
@@ -1,0 +1,98 @@
+defmodule Ecto.Adapters.Exqlite.Codec do
+  def bool_decode(nil), do: {:ok, nil}
+  def bool_decode(0), do: {:ok, false}
+  def bool_decode("0"), do: {:ok, false}
+  def bool_decode("FALSE"), do: {:ok, false}
+  def bool_decode(1), do: {:ok, true}
+  def bool_decode("1"), do: {:ok, true}
+  def bool_decode("TRUE"), do: {:ok, true}
+  def bool_decode(_), do: :error
+
+  def json_decode(nil), do: {:ok, nil}
+
+  def json_decode(x) when is_binary(x) do
+    Application.get_env(:ecto, :json_library).decode(x)
+  end
+
+  def json_decode(_), do: :error
+
+  def float_decode(nil), do: {:ok, nil}
+  def float_decode(%Decimal{} = decimal), do: {:ok, Decimal.to_float(decimal)}
+  def float_decode(x) when is_integer(x), do: {:ok, x / 1}
+  def float_decode(_), do: :error
+
+  def decimal_decode(nil), do: {:ok, nil}
+
+  def decimal_decode(x) when is_float(x) do
+    try do
+      {:ok, Decimal.from_float(x)}
+    catch
+      Decimal.Error -> :error
+    end
+  end
+
+  def decimal_decode(x) when is_binary(x) or is_integer(x) do
+    try do
+      {:ok, Decimal.new(x)}
+    catch
+      Decimal.Error -> :error
+    end
+  end
+
+  def decimal_decode(_), do: :error
+
+  def datetime_decode(nil), do: {:ok, nil}
+
+  def datetime_decode(val) do
+    # TODO: Should we be preserving the timezone? SQLite3 stores everything
+    #       shifted to UTC. sqlite_ecto2 used a custom field type "TEXT_DATETIME"
+    #       to preserve the original string inserted. But I don't know if that
+    #       is desirable or not.
+    #
+    #       @warmwaffles 2021-02-28
+    case DateTime.from_iso8601(val) do
+      {:ok, dt, _offset} -> {:ok, dt}
+      _ -> :error
+    end
+  end
+
+  def naive_datetime_decode(nil), do: {:ok, nil}
+
+  def naive_datetime_decode(val) do
+    case NaiveDateTime.from_iso8601(val) do
+      {:ok, dt} -> {:ok, dt}
+      _ -> :error
+    end
+  end
+
+  def date_decode(nil), do: {:ok, nil}
+
+  def date_decode(val) do
+    case Date.from_iso8601(val) do
+      {:ok, d} -> {:ok, d}
+      _ -> :error
+    end
+  end
+
+  def json_encode(value) do
+    Application.get_env(:ecto, :json_library).encode(value)
+  end
+
+  def blob_encode(value), do: {:ok, {:blob, value}}
+
+  def bool_encode(false), do: {:ok, 0}
+  def bool_encode(true), do: {:ok, 1}
+
+  def decimal_encode(%Decimal{} = x) do
+    {:ok, Decimal.to_string(x, :normal)}
+  end
+  # def decimal_encode(x), do: {:ok, x}
+
+  def time_encode(value) do
+    {:ok, value}
+  end
+
+  def naive_datetime_encode(value) do
+    {:ok, NaiveDateTime.to_iso8601(value)}
+  end
+end

--- a/test/ecto/adapters/exqlite/codec_test.exs
+++ b/test/ecto/adapters/exqlite/codec_test.exs
@@ -1,0 +1,83 @@
+defmodule Ecto.Adapters.Exqlite.CodecTest do
+  use ExUnit.Case, async: true
+
+  alias Ecto.Adapters.Exqlite.Codec
+
+  describe ".bool_decode/1" do
+    test "0" do
+      {:ok, false} = Codec.bool_decode(0)
+      {:ok, false} = Codec.bool_decode("0")
+    end
+
+    test "FALSE" do
+      {:ok, false} = Codec.bool_decode("FALSE")
+    end
+
+    test "1" do
+      {:ok, true} = Codec.bool_decode(1)
+      {:ok, true} = Codec.bool_decode("1")
+    end
+
+    test "TRUE" do
+      {:ok, true} = Codec.bool_decode("TRUE")
+    end
+  end
+
+  describe ".json_decode/1" do
+    test "nil" do
+      {:ok, nil} = Codec.json_decode(nil)
+    end
+
+    test "valid json" do
+      {:ok, %{}} = Codec.json_decode("{}")
+      {:ok, []} = Codec.json_decode("[]")
+      {:ok, %{"foo" => 1}} = Codec.json_decode(~s|{"foo":1}|)
+    end
+
+    test "handles malformed json" do
+      {:error, _} = Codec.json_decode("")
+      {:error, _} = Codec.json_decode(" ")
+      {:error, _} = Codec.json_decode("{")
+      {:error, _} = Codec.json_decode("[")
+    end
+  end
+
+  describe ".float_decode/1" do
+    test "nil" do
+      {:ok, nil} = Codec.float_decode(nil)
+    end
+
+    test "integer" do
+      {:ok, 1.0} = Codec.float_decode(1)
+      {:ok, 2.0} = Codec.float_decode(2)
+    end
+
+    test "Decimal" do
+      {:ok, 1.0} = Codec.float_decode(Decimal.new("1.0"))
+    end
+  end
+
+  describe ".decimal_decode/1" do
+    test "nil" do
+      {:ok, nil} = Codec.decimal_decode(nil)
+    end
+
+    test "string" do
+      decimal = Decimal.new("1")
+      {:ok, ^decimal} = Codec.decimal_decode("1")
+
+      decimal = Decimal.new("1.0")
+      {:ok, ^decimal} = Codec.decimal_decode("1.0")
+    end
+
+    test "integer" do
+      decimal = Decimal.new("2")
+      {:ok, ^decimal} = Codec.decimal_decode(2)
+    end
+
+    test "float" do
+      decimal = Decimal.from_float(1.2)
+      {:ok, ^decimal} = Codec.decimal_decode(1.2)
+    end
+  end
+end


### PR DESCRIPTION
@kevinlang this is a different approach from #56 

If you uncomment this

```
# Code.require_file "#{ecto}/integration_test/cases/type.exs", __DIR__
```

And run 

```
EXQLITE_INTEGRATION=true mix test --only decimal_type --seed 0
```

You'll see that it at least returns numerically correct values. The biggest issue right now is that this happens

```
  3) test on coalesce with mixed types (Ecto.Integration.TypeTest)
     deps/ecto/integration_test/cases/type.exs:444
     match (=) failed
     The following variables were pinned:
       decimal = #Decimal<1.0>
     code:  assert [^decimal] = TestRepo.all(from(p in Post, select: coalesce(p.cost, 0)))
     left:  [^decimal]
     right: [1]
     stacktrace:
       deps/ecto/integration_test/cases/type.exs:447: (test)
```

It's being returned as an integer and another one is being returned as a normalized `Decimal` value.