### PR TITLE
fix update_all encoding nil to "NULL"

### DIFF
--- a/c_src/sqlite3_nif.c
+++ b/c_src/sqlite3_nif.c
@@ -287,7 +287,7 @@ bind(ErlNifEnv* env, const ERL_NIF_TERM arg, sqlite3_stmt* statement, int index)
     }
 
     if (enif_get_atom(env, arg, the_atom, sizeof(the_atom), ERL_NIF_LATIN1)) {
-        if (0 == utf8ncmp("undefined", the_atom, 9)) {
+        if (0 == utf8ncmp("undefined", the_atom, 9) || 0 == utf8ncmp("nil", the_atom, 3)) {
             return sqlite3_bind_null(statement, index);
         }
 

--- a/lib/exqlite/sqlite3.ex
+++ b/lib/exqlite/sqlite3.ex
@@ -113,6 +113,5 @@ defmodule Exqlite.Sqlite3 do
   defp convert(%DateTime{} = val), do: DateTime.to_iso8601(val)
   defp convert(%Time{} = val), do: Time.to_iso8601(val)
   defp convert(%NaiveDateTime{} = val), do: NaiveDateTime.to_iso8601(val)
-  defp convert(nil), do: "NULL"
   defp convert(val), do: val
 end

--- a/test/ecto/integration/crud_test.exs
+++ b/test/ecto/integration/crud_test.exs
@@ -102,6 +102,12 @@ defmodule Ecto.Integration.CrudTest do
 
       assert changed.name == "Bob"
     end
+
+    test "update_all handles null<->nil conversion correctly" do
+      account = TestRepo.insert!(%Account{name: "hello"})
+      assert {1, nil} = TestRepo.update_all(Account, set: [name: nil])
+      assert %Account{name: nil} = TestRepo.reload(account)
+    end
   end
 
   describe "transaction" do
@@ -181,12 +187,5 @@ defmodule Ecto.Integration.CrudTest do
         assert Ecto.assoc_loaded?(account.users)
       end)
     end
-  end
-
-  test "handles null<->nil conversion correctly" do
-    account = TestRepo.insert!(%Account{name: nil})
-    assert account.name == nil
-    found = TestRepo.get(Account, account.id)
-    assert found.name == nil
   end
 end

--- a/test/ecto/integration/crud_test.exs
+++ b/test/ecto/integration/crud_test.exs
@@ -182,4 +182,11 @@ defmodule Ecto.Integration.CrudTest do
       end)
     end
   end
+
+  test "handles null<->nil conversion correctly" do
+    account = TestRepo.insert!(%Account{name: nil})
+    assert account.name == nil
+    found = TestRepo.get(Account, account.id)
+    assert found.name == nil
+  end
 end


### PR DESCRIPTION
Discovered while trying to onboard `repo.exs`.