### PR TITLE
onboard joins.exs integration tests

### DIFF
--- a/integration_test/exqlite/all_test.exs
+++ b/integration_test/exqlite/all_test.exs
@@ -3,7 +3,7 @@ ecto_sql = Mix.Project.deps_paths()[:ecto_sql]
 
 # Code.require_file "#{ecto}/integration_test/cases/assoc.exs", __DIR__
 # Code.require_file "#{ecto}/integration_test/cases/interval.exs", __DIR__
-# Code.require_file "#{ecto}/integration_test/cases/joins.exs", __DIR__
+Code.require_file "#{ecto}/integration_test/cases/joins.exs", __DIR__
 Code.require_file "#{ecto}/integration_test/cases/preload.exs", __DIR__
 # Code.require_file "#{ecto}/integration_test/cases/repo.exs", __DIR__
 # Code.require_file "#{ecto}/integration_test/cases/type.exs", __DIR__

--- a/integration_test/exqlite/test_helper.exs
+++ b/integration_test/exqlite/test_helper.exs
@@ -74,6 +74,8 @@ Process.flag(:trap_exit, true)
 
 ExUnit.start(
   exclude: [
+    :delete_with_join,
+    :right_join,
     # SQLite does not have an array type
     :array_type,
     :transaction_isolation,


### PR DESCRIPTION
Tests will pass once #71 is merged (underlying issue is due to `:json_library` not being defined for `:ecto`, which is fixed there).