### PR TITLE
 onboard interval.exs integration tests 

### DIFF
--- a/integration_test/exqlite/all_test.exs
+++ b/integration_test/exqlite/all_test.exs
@@ -17,6 +17,10 @@ Code.require_file "#{ecto_sql}/integration_test/sql/logging.exs", __DIR__
 # necessary to fork into the repo as it relies on :ecto_sql app, which
 # we modified to be :exqlite app until we merge into ecto_sql
 Code.require_file "./ecto_sql/sandbox.exs", __DIR__
+# Since sqlite does not have microsecond precision we forked these tests
+# and added some additionals tests for datetime types
+Code.require_file "./cases/interval.exs", __DIR__
+
 
 Code.require_file "#{ecto_sql}/integration_test/sql/sql.exs", __DIR__
 Code.require_file "#{ecto_sql}/integration_test/sql/stream.exs", __DIR__

--- a/integration_test/exqlite/cases/interval.exs
+++ b/integration_test/exqlite/cases/interval.exs
@@ -1,0 +1,423 @@
+defmodule Ecto.Integration.IntervalTest do
+  use Ecto.Integration.Case, async: Application.get_env(:ecto, :async_integration_tests, true)
+
+  alias Ecto.Integration.{Post, User, Usec}
+  alias Ecto.Integration.TestRepo
+  import Ecto.Query
+
+  @posted ~D[2014-01-01]
+  @inserted_at ~N[2014-01-01 02:00:00]
+
+  setup do
+    TestRepo.insert!(%Post{posted: @posted, inserted_at: @inserted_at})
+    :ok
+  end
+
+  test "date_add with year" do
+    dec = Decimal.new(1)
+    assert [~D[2015-01-01]] = TestRepo.all(from p in Post, select: date_add(p.posted, 1, "year"))
+    assert [~D[2015-01-01]] = TestRepo.all(from p in Post, select: date_add(p.posted, 1.0, "year"))
+    assert [~D[2015-01-01]] = TestRepo.all(from p in Post, select: date_add(p.posted, ^1, "year"))
+    assert [~D[2015-01-01]] = TestRepo.all(from p in Post, select: date_add(p.posted, ^1.0, "year"))
+    assert [~D[2015-01-01]] = TestRepo.all(from p in Post, select: date_add(p.posted, ^dec, "year"))
+  end
+
+  test "date_add with month" do
+    dec = Decimal.new(3)
+    assert [~D[2014-04-01]] = TestRepo.all(from p in Post, select: date_add(p.posted, 3, "month"))
+    assert [~D[2014-04-01]] = TestRepo.all(from p in Post, select: date_add(p.posted, 3.0, "month"))
+    assert [~D[2014-04-01]] = TestRepo.all(from p in Post, select: date_add(p.posted, ^3, "month"))
+    assert [~D[2014-04-01]] = TestRepo.all(from p in Post, select: date_add(p.posted, ^3.0, "month"))
+    assert [~D[2014-04-01]] = TestRepo.all(from p in Post, select: date_add(p.posted, ^dec, "month"))
+  end
+
+  test "date_add with week" do
+    dec = Decimal.new(3)
+    assert [~D[2014-01-22]] = TestRepo.all(from p in Post, select: date_add(p.posted, 3, "week"))
+    assert [~D[2014-01-22]] = TestRepo.all(from p in Post, select: date_add(p.posted, 3.0, "week"))
+    assert [~D[2014-01-22]] = TestRepo.all(from p in Post, select: date_add(p.posted, ^3, "week"))
+    assert [~D[2014-01-22]] = TestRepo.all(from p in Post, select: date_add(p.posted, ^3.0, "week"))
+    assert [~D[2014-01-22]] = TestRepo.all(from p in Post, select: date_add(p.posted, ^dec, "week"))
+  end
+
+  test "date_add with day" do
+    dec = Decimal.new(5)
+    assert [~D[2014-01-06]] = TestRepo.all(from p in Post, select: date_add(p.posted, 5, "day"))
+    assert [~D[2014-01-06]] = TestRepo.all(from p in Post, select: date_add(p.posted, 5.0, "day"))
+    assert [~D[2014-01-06]] = TestRepo.all(from p in Post, select: date_add(p.posted, ^5, "day"))
+    assert [~D[2014-01-06]] = TestRepo.all(from p in Post, select: date_add(p.posted, ^5.0, "day"))
+    assert [~D[2014-01-06]] = TestRepo.all(from p in Post, select: date_add(p.posted, ^dec, "day"))
+  end
+
+  test "date_add with hour" do
+    dec = Decimal.new(48)
+    assert [~D[2014-01-03]] = TestRepo.all(from p in Post, select: date_add(p.posted, 48, "hour"))
+    assert [~D[2014-01-03]] = TestRepo.all(from p in Post, select: date_add(p.posted, 48.0, "hour"))
+    assert [~D[2014-01-03]] = TestRepo.all(from p in Post, select: date_add(p.posted, ^48, "hour"))
+    assert [~D[2014-01-03]] = TestRepo.all(from p in Post, select: date_add(p.posted, ^48.0, "hour"))
+    assert [~D[2014-01-03]] = TestRepo.all(from p in Post, select: date_add(p.posted, ^dec, "hour"))
+  end
+
+  test "date_add with dynamic" do
+    posted = @posted
+    assert [~D[2015-01-01]]  = TestRepo.all(from p in Post, select: date_add(^posted, ^1, ^"year"))
+    assert [~D[2014-04-01]]  = TestRepo.all(from p in Post, select: date_add(^posted, ^3, ^"month"))
+    assert [~D[2014-01-22]] = TestRepo.all(from p in Post, select: date_add(^posted, ^3, ^"week"))
+    assert [~D[2014-01-06]]  = TestRepo.all(from p in Post, select: date_add(^posted, ^5, ^"day"))
+    assert [~D[2014-01-03]]  = TestRepo.all(from p in Post, select: date_add(^posted, ^48, ^"hour"))
+  end
+
+  test "date_add with negative interval" do
+    dec = Decimal.new(-1)
+    assert [~D[2013-01-01]] = TestRepo.all(from p in Post, select: date_add(p.posted, -1, "year"))
+    assert [~D[2013-01-01]] = TestRepo.all(from p in Post, select: date_add(p.posted, -1.0, "year"))
+    assert [~D[2013-01-01]] = TestRepo.all(from p in Post, select: date_add(p.posted, ^-1, "year"))
+    assert [~D[2013-01-01]] = TestRepo.all(from p in Post, select: date_add(p.posted, ^-1.0, "year"))
+    assert [~D[2013-01-01]] = TestRepo.all(from p in Post, select: date_add(p.posted, ^dec, "year"))
+  end
+
+  test "datetime_add with year" do
+    dec = Decimal.new(1)
+    assert [~N[2015-01-01 02:00:00]] =
+           TestRepo.all(from p in Post, select: datetime_add(p.inserted_at, 1, "year"))
+    assert [~N[2015-01-01 02:00:00]] =
+           TestRepo.all(from p in Post, select: datetime_add(p.inserted_at, 1.0, "year"))
+    assert [~N[2015-01-01 02:00:00]] =
+           TestRepo.all(from p in Post, select: datetime_add(p.inserted_at, ^1, "year"))
+    assert [~N[2015-01-01 02:00:00]] =
+           TestRepo.all(from p in Post, select: datetime_add(p.inserted_at, ^1.0, "year"))
+    assert [~N[2015-01-01 02:00:00]] =
+           TestRepo.all(from p in Post, select: datetime_add(p.inserted_at, ^dec, "year"))
+  end
+
+  test "datetime_add with month" do
+    dec = Decimal.new(3)
+    assert [~N[2014-04-01 02:00:00]] =
+           TestRepo.all(from p in Post, select: datetime_add(p.inserted_at, 3, "month"))
+    assert [~N[2014-04-01 02:00:00]] =
+           TestRepo.all(from p in Post, select: datetime_add(p.inserted_at, 3.0, "month"))
+    assert [~N[2014-04-01 02:00:00]] =
+           TestRepo.all(from p in Post, select: datetime_add(p.inserted_at, ^3, "month"))
+    assert [~N[2014-04-01 02:00:00]] =
+           TestRepo.all(from p in Post, select: datetime_add(p.inserted_at, ^3.0, "month"))
+    assert [~N[2014-04-01 02:00:00]] =
+           TestRepo.all(from p in Post, select: datetime_add(p.inserted_at, ^dec, "month"))
+  end
+
+  test "datetime_add with week" do
+    dec = Decimal.new(3)
+    assert [~N[2014-01-22 02:00:00]] =
+            TestRepo.all(from p in Post, select: datetime_add(p.inserted_at, 3, "week"))
+    assert [~N[2014-01-22 02:00:00]] =
+            TestRepo.all(from p in Post, select: datetime_add(p.inserted_at, 3.0, "week"))
+    assert [~N[2014-01-22 02:00:00]] =
+            TestRepo.all(from p in Post, select: datetime_add(p.inserted_at, ^3, "week"))
+    assert [~N[2014-01-22 02:00:00]] =
+            TestRepo.all(from p in Post, select: datetime_add(p.inserted_at, ^3.0, "week"))
+    assert [~N[2014-01-22 02:00:00]] =
+            TestRepo.all(from p in Post, select: datetime_add(p.inserted_at, ^dec, "week"))
+  end
+
+  test "datetime_add with day" do
+    dec = Decimal.new(5)
+    assert [~N[2014-01-06 02:00:00]] =
+           TestRepo.all(from p in Post, select: datetime_add(p.inserted_at, 5, "day"))
+    assert [~N[2014-01-06 02:00:00]] =
+           TestRepo.all(from p in Post, select: datetime_add(p.inserted_at, 5.0, "day"))
+    assert [~N[2014-01-06 02:00:00]] =
+           TestRepo.all(from p in Post, select: datetime_add(p.inserted_at, ^5, "day"))
+    assert [~N[2014-01-06 02:00:00]] =
+           TestRepo.all(from p in Post, select: datetime_add(p.inserted_at, ^5.0, "day"))
+    assert [~N[2014-01-06 02:00:00]] =
+           TestRepo.all(from p in Post, select: datetime_add(p.inserted_at, ^dec, "day"))
+  end
+
+  test "datetime_add with hour" do
+    dec = Decimal.new(60)
+    assert [~N[2014-01-03 14:00:00]] =
+           TestRepo.all(from p in Post, select: datetime_add(p.inserted_at, 60, "hour"))
+    assert [~N[2014-01-03 14:00:00]] =
+           TestRepo.all(from p in Post, select: datetime_add(p.inserted_at, 60.0, "hour"))
+    assert [~N[2014-01-03 14:00:00]] =
+           TestRepo.all(from p in Post, select: datetime_add(p.inserted_at, ^60, "hour"))
+    assert [~N[2014-01-03 14:00:00]] =
+           TestRepo.all(from p in Post, select: datetime_add(p.inserted_at, ^60.0, "hour"))
+    assert [~N[2014-01-03 14:00:00]] =
+           TestRepo.all(from p in Post, select: datetime_add(p.inserted_at, ^dec, "hour"))
+  end
+
+  test "datetime_add with minute" do
+    dec = Decimal.new(90)
+    assert [~N[2014-01-01 03:30:00]] =
+           TestRepo.all(from p in Post, select: datetime_add(p.inserted_at, 90, "minute"))
+    assert [~N[2014-01-01 03:30:00]] =
+           TestRepo.all(from p in Post, select: datetime_add(p.inserted_at, 90.0, "minute"))
+    assert [~N[2014-01-01 03:30:00]] =
+           TestRepo.all(from p in Post, select: datetime_add(p.inserted_at, ^90, "minute"))
+    assert [~N[2014-01-01 03:30:00]] =
+           TestRepo.all(from p in Post, select: datetime_add(p.inserted_at, ^90.0, "minute"))
+    assert [~N[2014-01-01 03:30:00]] =
+           TestRepo.all(from p in Post, select: datetime_add(p.inserted_at, ^dec, "minute"))
+  end
+
+  test "datetime_add with second" do
+    dec = Decimal.new(90)
+    assert [~N[2014-01-01 02:01:30]] =
+           TestRepo.all(from p in Post, select: datetime_add(p.inserted_at, 90, "second"))
+    assert [~N[2014-01-01 02:01:30]] =
+           TestRepo.all(from p in Post, select: datetime_add(p.inserted_at, 90.0, "second"))
+    assert [~N[2014-01-01 02:01:30]] =
+           TestRepo.all(from p in Post, select: datetime_add(p.inserted_at, ^90, "second"))
+    assert [~N[2014-01-01 02:01:30]] =
+           TestRepo.all(from p in Post, select: datetime_add(p.inserted_at, ^90.0, "second"))
+    assert [~N[2014-01-01 02:01:30]] =
+           TestRepo.all(from p in Post, select: datetime_add(p.inserted_at, ^dec, "second"))
+  end
+
+  @tag :uses_msec
+  test "datetime_add with millisecond" do
+    dec = Decimal.new(1500)
+    assert [~N[2014-01-01 02:00:01]] =
+           TestRepo.all(from p in Post, select: datetime_add(p.inserted_at, 1500, "millisecond"))
+    assert [~N[2014-01-01 02:00:01]] =
+           TestRepo.all(from p in Post, select: datetime_add(p.inserted_at, 1500.0, "millisecond"))
+    assert [~N[2014-01-01 02:00:01]] =
+           TestRepo.all(from p in Post, select: datetime_add(p.inserted_at, ^1500, "millisecond"))
+    assert [~N[2014-01-01 02:00:01]] =
+           TestRepo.all(from p in Post, select: datetime_add(p.inserted_at, ^1500.0, "millisecond"))
+    assert [~N[2014-01-01 02:00:01]] =
+           TestRepo.all(from p in Post, select: datetime_add(p.inserted_at, ^dec, "millisecond"))
+  end
+
+  @tag :microsecond_precision
+  @tag :uses_usec
+  test "datetime_add with microsecond" do
+    dec = Decimal.new(1500)
+    assert [~N[2014-01-01 02:00:00]] =
+           TestRepo.all(from p in Post, select: datetime_add(p.inserted_at, 1500, "microsecond"))
+    assert [~N[2014-01-01 02:00:00]] =
+           TestRepo.all(from p in Post, select: datetime_add(p.inserted_at, 1500.0, "microsecond"))
+    assert [~N[2014-01-01 02:00:00]] =
+           TestRepo.all(from p in Post, select: datetime_add(p.inserted_at, ^1500, "microsecond"))
+    assert [~N[2014-01-01 02:00:00]] =
+           TestRepo.all(from p in Post, select: datetime_add(p.inserted_at, ^1500.0, "microsecond"))
+    assert [~N[2014-01-01 02:00:00]] =
+           TestRepo.all(from p in Post, select: datetime_add(p.inserted_at, ^dec, "microsecond"))
+  end
+
+  test "datetime_add with dynamic" do
+    inserted_at = @inserted_at
+    assert [~N[2015-01-01 02:00:00]]  =
+           TestRepo.all(from p in Post, select: datetime_add(^inserted_at, ^1, ^"year"))
+    assert [~N[2014-04-01 02:00:00]]  =
+           TestRepo.all(from p in Post, select: datetime_add(^inserted_at, ^3, ^"month"))
+    assert [~N[2014-01-22 02:00:00]] =
+           TestRepo.all(from p in Post, select: datetime_add(^inserted_at, ^3, ^"week"))
+    assert [~N[2014-01-06 02:00:00]]  =
+           TestRepo.all(from p in Post, select: datetime_add(^inserted_at, ^5, ^"day"))
+    assert [~N[2014-01-03 14:00:00]] =
+           TestRepo.all(from p in Post, select: datetime_add(^inserted_at, ^60, ^"hour"))
+    assert [~N[2014-01-01 03:30:00]] =
+           TestRepo.all(from p in Post, select: datetime_add(^inserted_at, ^90, ^"minute"))
+    assert [~N[2014-01-01 02:01:30]] =
+           TestRepo.all(from p in Post, select: datetime_add(^inserted_at, ^90, ^"second"))
+  end
+
+  test "datetime_add with dynamic in filters" do
+    inserted_at = @inserted_at
+    field = :inserted_at
+    assert [_]  =
+           TestRepo.all(from p in Post, where: p.inserted_at > datetime_add(^inserted_at, ^-1, "year"))
+    assert [_]  =
+           TestRepo.all(from p in Post, where: p.inserted_at > datetime_add(^inserted_at, -3, "month"))
+    assert [_]  =
+           TestRepo.all(from p in Post, where: field(p, ^field) > datetime_add(^inserted_at, ^-3, ^"week"))
+    assert [_]  =
+           TestRepo.all(from p in Post, where: field(p, ^field) > datetime_add(^inserted_at, -5, ^"day"))
+  end
+
+  test "datetime_add with negative interval" do
+    dec = Decimal.new(-1)
+    assert [~N[2013-01-01 02:00:00]] =
+           TestRepo.all(from p in Post, select: datetime_add(p.inserted_at, -1, "year"))
+    assert [~N[2013-01-01 02:00:00]] =
+           TestRepo.all(from p in Post, select: datetime_add(p.inserted_at, -1.0, "year"))
+    assert [~N[2013-01-01 02:00:00]] =
+           TestRepo.all(from p in Post, select: datetime_add(p.inserted_at, ^-1, "year"))
+    assert [~N[2013-01-01 02:00:00]] =
+           TestRepo.all(from p in Post, select: datetime_add(p.inserted_at, ^-1.0, "year"))
+    assert [~N[2013-01-01 02:00:00]] =
+           TestRepo.all(from p in Post, select: datetime_add(p.inserted_at, ^dec, "year"))
+  end
+
+  test "from_now" do
+    current = DateTime.utc_now().year
+    dec = Decimal.new(5)
+    assert [%{year: year}] = TestRepo.all(from p in Post, select: from_now(5, "year"))
+    assert year > current
+    assert [%{year: year}] = TestRepo.all(from p in Post, select: from_now(5.0, "year"))
+    assert year > current
+    assert [%{year: year}] = TestRepo.all(from p in Post, select: from_now(^5, "year"))
+    assert year > current
+    assert [%{year: year}] = TestRepo.all(from p in Post, select: from_now(^5.0, "year"))
+    assert year > current
+    assert [%{year: year}] = TestRepo.all(from p in Post, select: from_now(^dec, "year"))
+    assert year > current
+  end
+
+  test "ago" do
+    current = DateTime.utc_now().year
+    dec = Decimal.new(5)
+    assert [%{year: year}] = TestRepo.all(from p in Post, select: ago(5, "year"))
+    assert year < current
+    assert [%{year: year}] = TestRepo.all(from p in Post, select: ago(5.0, "year"))
+    assert year < current
+    assert [%{year: year}] = TestRepo.all(from p in Post, select: ago(^5, "year"))
+    assert year < current
+    assert [%{year: year}] = TestRepo.all(from p in Post, select: ago(^5.0, "year"))
+    assert year < current
+    assert [%{year: year}] = TestRepo.all(from p in Post, select: ago(^dec, "year"))
+    assert year < current
+  end
+
+  test "datetime_add with utc_datetime" do
+    {:ok, datetime} = DateTime.from_naive(@inserted_at, "Etc/UTC")
+    TestRepo.insert!(%User{inserted_at: datetime})
+
+    {:ok, datetime} = DateTime.from_naive(~N[2015-01-01 02:00:00], "Etc/UTC")
+    dec = Decimal.new(1)
+
+    assert [^datetime] =
+           TestRepo.all(from p in User, select: datetime_add(type(^datetime, :utc_datetime), 0, "year"))
+    assert [^datetime] =
+           TestRepo.all(from p in User, select: datetime_add(p.inserted_at, 1, "year"))
+    assert [^datetime] =
+           TestRepo.all(from p in User, select: datetime_add(p.inserted_at, 1.0, "year"))
+    assert [^datetime] =
+           TestRepo.all(from p in User, select: datetime_add(p.inserted_at, ^1, "year"))
+    assert [^datetime] =
+           TestRepo.all(from p in User, select: datetime_add(p.inserted_at, ^1.0, "year"))
+    assert [^datetime] =
+           TestRepo.all(from p in User, select: datetime_add(p.inserted_at, ^dec, "year"))
+  end
+
+  @tag :microsecond_precision
+  test "datetime_add with naive_datetime_usec" do
+    TestRepo.insert!(%Usec{naive_datetime_usec: ~N[2014-01-01 02:00:00.000001]})
+    datetime = ~N[2014-01-01 02:00:00.001501]
+
+    assert [^datetime] =
+           TestRepo.all(from u in Usec, select: datetime_add(type(^datetime, :naive_datetime_usec), 0, "microsecond"))
+    assert [^datetime] =
+           TestRepo.all(from u in Usec, select: datetime_add(u.naive_datetime_usec, 1500, "microsecond"))
+    assert [^datetime] =
+           TestRepo.all(from u in Usec, select: datetime_add(u.naive_datetime_usec, 1500.0, "microsecond"))
+    assert [^datetime] =
+           TestRepo.all(from u in Usec, select: datetime_add(u.naive_datetime_usec, ^1500, "microsecond"))
+  end
+
+  @tag :microsecond_precision
+  @tag :decimal_precision
+  test "datetime_add with naive_datetime_usec and decimal increment" do
+    TestRepo.insert!(%Usec{naive_datetime_usec: ~N[2014-01-01 02:00:00.000001]})
+    dec = Decimal.new(1500)
+    datetime = ~N[2014-01-01 02:00:00.001501]
+
+    assert [^datetime] =
+           TestRepo.all(from u in Usec, select: datetime_add(u.naive_datetime_usec, ^1500.0, "microsecond"))
+    assert [^datetime] =
+           TestRepo.all(from u in Usec, select: datetime_add(u.naive_datetime_usec, ^dec, "microsecond"))
+  end
+
+
+  @tag :microsecond_precision
+  test "datetime_add with utc_datetime_usec" do
+    {:ok, datetime} = DateTime.from_naive(~N[2014-01-01 02:00:00.000001], "Etc/UTC")
+    TestRepo.insert!(%Usec{utc_datetime_usec: datetime})
+
+    {:ok, datetime} = DateTime.from_naive(~N[2014-01-01 02:00:00.001501], "Etc/UTC")
+
+    assert [^datetime] =
+           TestRepo.all(from u in Usec, select: datetime_add(type(^datetime, :utc_datetime_usec), 0, "microsecond"))
+    assert [^datetime] =
+           TestRepo.all(from u in Usec, select: datetime_add(u.utc_datetime_usec, 1500, "microsecond"))
+    assert [^datetime] =
+           TestRepo.all(from u in Usec, select: datetime_add(u.utc_datetime_usec, 1500.0, "microsecond"))
+    assert [^datetime] =
+           TestRepo.all(from u in Usec, select: datetime_add(u.utc_datetime_usec, ^1500, "microsecond"))
+  end
+
+  @tag :microsecond_precision
+  @tag :decimal_precision
+  test "datetime_add uses utc_datetime_usec with decimal increment" do
+    {:ok, datetime} = DateTime.from_naive(~N[2014-01-01 02:00:00.000001], "Etc/UTC")
+    TestRepo.insert!(%Usec{utc_datetime_usec: datetime})
+
+    {:ok, datetime} = DateTime.from_naive(~N[2014-01-01 02:00:00.001501], "Etc/UTC")
+    dec = Decimal.new(1500)
+
+    assert [^datetime] =
+           TestRepo.all(from u in Usec, select: datetime_add(u.utc_datetime_usec, ^1500.0, "microsecond"))
+    assert [^datetime] =
+           TestRepo.all(from u in Usec, select: datetime_add(u.utc_datetime_usec, ^dec, "microsecond"))
+  end
+
+
+  test "datetime_add with utc_datetime_usec in milliseconds" do
+    {:ok, datetime} = DateTime.from_naive(~N[2014-01-01 02:00:00.001000], "Etc/UTC")
+    TestRepo.insert!(%Usec{utc_datetime_usec: datetime})
+
+    {:ok, datetime} = DateTime.from_naive(~N[2014-01-01 02:00:00.151000], "Etc/UTC")
+
+    assert [^datetime] =
+           TestRepo.all(from u in Usec, select: datetime_add(type(^datetime, :utc_datetime_usec), 0, "millisecond"))
+    assert [^datetime] =
+           TestRepo.all(from u in Usec, select: datetime_add(u.utc_datetime_usec, 150, "millisecond"))
+    assert [^datetime] =
+           TestRepo.all(from u in Usec, select: datetime_add(u.utc_datetime_usec, 150, "millisecond"))
+    assert [^datetime] =
+           TestRepo.all(from u in Usec, select: datetime_add(u.utc_datetime_usec, ^150, "millisecond"))
+  end
+
+  @tag :decimal_precision
+  test "datetime_add uses utc_datetime_usec with decimal increment in milliseconds" do
+    {:ok, datetime} = DateTime.from_naive(~N[2014-01-01 02:00:00.001000], "Etc/UTC")
+    TestRepo.insert!(%Usec{utc_datetime_usec: datetime})
+
+    {:ok, datetime} = DateTime.from_naive(~N[2014-01-01 02:00:00.151000], "Etc/UTC")
+    dec = Decimal.new(150)
+
+    assert [^datetime] =
+           TestRepo.all(from u in Usec, select: datetime_add(u.utc_datetime_usec, ^150.0, "millisecond"))
+    assert [^datetime] =
+           TestRepo.all(from u in Usec, select: datetime_add(u.utc_datetime_usec, ^dec, "millisecond"))
+  end
+
+
+  @tag :decimal_precision
+  test "datetime_add with naive_datetime_usec in milliseconds" do
+    TestRepo.insert!(%Usec{naive_datetime_usec: ~N[2014-01-01 02:00:00.001000]})
+    datetime = ~N[2014-01-01 02:00:00.151000]
+
+    assert [^datetime] =
+           TestRepo.all(from u in Usec, select: datetime_add(type(^datetime, :naive_datetime_usec), 0, "millisecond"))
+    assert [^datetime] =
+           TestRepo.all(from u in Usec, select: datetime_add(u.naive_datetime_usec, 150, "millisecond"))
+    assert [^datetime] =
+           TestRepo.all(from u in Usec, select: datetime_add(u.naive_datetime_usec, 150.0, "millisecond"))
+    assert [^datetime] =
+           TestRepo.all(from u in Usec, select: datetime_add(u.naive_datetime_usec, ^150, "millisecond"))
+  end
+
+  @tag :decimal_precision
+  test "datetime_add with naive_datetime_usec and decimal increment in milliseconds" do
+    TestRepo.insert!(%Usec{naive_datetime_usec: ~N[2014-01-01 02:00:00.001000]})
+    dec = Decimal.new(150)
+    datetime = ~N[2014-01-01 02:00:00.151000]
+
+    assert [^datetime] =
+           TestRepo.all(from u in Usec, select: datetime_add(u.naive_datetime_usec, ^150.0, "millisecond"))
+    assert [^datetime] =
+           TestRepo.all(from u in Usec, select: datetime_add(u.naive_datetime_usec, ^dec, "millisecond"))
+  end
+end

--- a/integration_test/exqlite/test_helper.exs
+++ b/integration_test/exqlite/test_helper.exs
@@ -80,6 +80,8 @@ ExUnit.start(
     :insert_cell_wise_defaults,
     :returning,
     :read_after_writes,
+    # sqlite does not support microsecond precision, only millisecond
+    :microsecond_precision,
     # sqlite supports FKs, but does not return sufficient data
     # for ecto to support matching on a given constraint violation name
     # which is what most of the tests validate

--- a/lib/ecto/adapters/exqlite.ex
+++ b/lib/ecto/adapters/exqlite.ex
@@ -112,6 +112,16 @@ defmodule Ecto.Adapters.Exqlite do
   end
 
   @impl Ecto.Adapter
+  def loaders(:naive_datetime_usec, type) do
+    [&Codec.datetime_decode/1, type]
+  end
+
+  @impl Ecto.Adapter
+  def loaders(:utc_datetime_usec, type) do
+    [&Codec.datetime_decode/1, type]
+  end
+
+  @impl Ecto.Adapter
   def loaders(:utc_datetime, type) do
     [&Codec.datetime_decode/1, type]
   end

--- a/lib/ecto/adapters/exqlite/connection.ex
+++ b/lib/ecto/adapters/exqlite/connection.ex
@@ -1151,7 +1151,7 @@ defmodule Ecto.Adapters.Exqlite.Connection do
   def expr({:datetime_add, _, [datetime, count, interval]}, sources, query) do
     [
       "CAST (",
-      "strftime('%Y-%m-%d %H:%M:%f000'",
+      "strftime('%Y-%m-%d %H:%M:%f000Z'",
       ",",
       expr(datetime, sources, query),
       ",",
@@ -1240,7 +1240,7 @@ defmodule Ecto.Adapters.Exqlite.Connection do
 
   def expr(%Ecto.Query.Tagged{value: other, type: type}, sources, query)
       when type in [:decimal, :float] do
-    [expr(other, sources, query), " + 0"]
+    ["(", expr(other, sources, query), " + 0)"]
   end
 
   def expr(%Ecto.Query.Tagged{value: other, type: type}, sources, query) do

--- a/lib/ecto/adapters/exqlite/data_type.ex
+++ b/lib/ecto/adapters/exqlite/data_type.ex
@@ -22,10 +22,10 @@ defmodule Ecto.Adapters.Exqlite.DataType do
   def column_type(:array, _opts), do: "JSON"
   def column_type({:map, _}, _opts), do: "JSON"
   def column_type({:array, _}, _opts), do: "JSON"
-  def column_type(:utc_datetime, _opts), do: "DATETIME"
-  def column_type(:utc_datetime_usec, _opts), do: "DATETIME"
-  def column_type(:naive_datetime, _opts), do: "DATETIME"
-  def column_type(:naive_datetime_usec, _opts), do: "DATETIME"
+  def column_type(:utc_datetime, _opts), do: "TEXT_DATETIME"
+  def column_type(:utc_datetime_usec, _opts), do: "TEXT_DATETIME"
+  def column_type(:naive_datetime, _opts), do: "TEXT_DATETIME"
+  def column_type(:naive_datetime_usec, _opts), do: "TEXT_DATETIME"
   def column_type(:decimal, nil), do: "DECIMAL"
 
   def column_type(:decimal, opts) do

--- a/test/ecto/adapters/exqlite/connection_test.exs
+++ b/test/ecto/adapters/exqlite/connection_test.exs
@@ -850,7 +850,7 @@ defmodule Ecto.Adapters.Exqlite.ConnectionTest do
       |> select(true)
       |> plan()
 
-    assert all(query) == "SELECT 1 FROM schema3 AS s0 ORDER BY s0.binary + 0"
+    assert all(query) == "SELECT 1 FROM schema3 AS s0 ORDER BY (s0.binary + 0)"
   end
 
   test "fragments" do
@@ -2252,8 +2252,8 @@ defmodule Ecto.Adapters.Exqlite.ConnectionTest do
     assert execute_ddl(create) == [
              """
              CREATE TABLE posts (\
-             published_at DATETIME, \
-             submitted_at DATETIME\
+             published_at TEXT_DATETIME, \
+             submitted_at TEXT_DATETIME\
              )\
              """
            ]
@@ -2268,7 +2268,7 @@ defmodule Ecto.Adapters.Exqlite.ConnectionTest do
        ]}
 
     assert execute_ddl(create) == [
-             "CREATE TABLE posts (published_at DATETIME, submitted_at DATETIME)"
+             "CREATE TABLE posts (published_at TEXT_DATETIME, submitted_at TEXT_DATETIME)"
            ]
   end
 
@@ -2358,7 +2358,7 @@ defmodule Ecto.Adapters.Exqlite.ConnectionTest do
              """,
              """
              ALTER TABLE posts \
-             ADD COLUMN when DATETIME\
+             ADD COLUMN when TEXT_DATETIME\
              """
            ]
   end

--- a/test/ecto/adapters/exqlite/data_type_test.exs
+++ b/test/ecto/adapters/exqlite/data_type_test.exs
@@ -65,19 +65,19 @@ defmodule Ecto.Adapters.Exqlite.DataTypeTest do
     end
 
     test ":utc_datetime is DATETIME" do
-      assert DataType.column_type(:utc_datetime, nil) == "DATETIME"
+      assert DataType.column_type(:utc_datetime, nil) == "TEXT_DATETIME"
     end
 
     test ":utc_datetime_usec is DATETIME" do
-      assert DataType.column_type(:utc_datetime_usec, nil) == "DATETIME"
+      assert DataType.column_type(:utc_datetime_usec, nil) == "TEXT_DATETIME"
     end
 
     test ":naive_datetime is DATETIME" do
-      assert DataType.column_type(:naive_datetime, nil) == "DATETIME"
+      assert DataType.column_type(:naive_datetime, nil) == "TEXT_DATETIME"
     end
 
     test ":naive_datetime_usec is DATETIME" do
-      assert DataType.column_type(:naive_datetime_usec, nil) == "DATETIME"
+      assert DataType.column_type(:naive_datetime_usec, nil) == "TEXT_DATETIME"
     end
   end
 end

--- a/test/ecto/integration/crud_test.exs
+++ b/test/ecto/integration/crud_test.exs
@@ -112,27 +112,23 @@ defmodule Ecto.Integration.CrudTest do
         |> TestRepo.transaction()
     end
 
-    # "cannot open savepoint - SQL statements in progress"
-    # which indicates we are not closing some of our statement handles
-    # properly, which is manifesting in this test not being able to run
-    # though it passes fine in isolation... - kcl
-    # test "unsuccessful account creation" do
-    #   {:error, _, _, _} =
-    #     Ecto.Multi.new()
-    #     |> Ecto.Multi.insert(:account, fn _ ->
-    #       Account.changeset(%Account{}, %{name: nil})
-    #     end)
-    #     |> Ecto.Multi.insert(:user, fn _ ->
-    #       User.changeset(%User{}, %{name: "Bob"})
-    #     end)
-    #     |> Ecto.Multi.insert(:account_user, fn %{account: account, user: user} ->
-    #       AccountUser.changeset(%AccountUser{}, %{
-    #         account_id: account.id,
-    #         user_id: user.id
-    #       })
-    #     end)
-    #     |> TestRepo.transaction()
-    # end
+    test "unsuccessful account creation" do
+      {:error, _, _, _} =
+        Ecto.Multi.new()
+        |> Ecto.Multi.insert(:account, fn _ ->
+          Account.changeset(%Account{}, %{name: nil})
+        end)
+        |> Ecto.Multi.insert(:user, fn _ ->
+          User.changeset(%User{}, %{name: "Bob"})
+        end)
+        |> Ecto.Multi.insert(:account_user, fn %{account: account, user: user} ->
+          AccountUser.changeset(%AccountUser{}, %{
+            account_id: account.id,
+            user_id: user.id
+          })
+        end)
+        |> TestRepo.transaction()
+    end
 
     test "unsuccessful user creation" do
       {:error, _, _, _} =


### PR DESCRIPTION
Since SQLite does not support microsecond precision, I've forked the interval tests for now and duplicated the ones that use microseconds to instead use milliseconds when validating different datetime types.

The reason I changed the "DATETIME" type to "TEXT_DATETIME" is that "DATETIME" would truncate the date and cast it incorrectly:
```
sqlite> SELECT strftime('%Y-%m-%d %H:%M:%f',CAST("2014-01-01 02:00:00.001501" AS DATETIME));
-470-05-30 12:00:00.000
```
With TEXT_DATETIME:
```
sqlite> SELECT strftime('%Y-%m-%d %H:%M:%f',CAST("2014-01-01 02:00:00.001501" AS TEXT_DATETIME));
2014-01-01 02:00:00.002
```

The Z addition is what's needed to load in the other datetime types. Otherwise Ecto fails to recognize and cast it.
And the parentheses are needed for sqlite to properly parse additions, otherwise it just grabs the first number.

The last thing is that I found a previously commented out test now works. I believe it was due to the resolved database_busy errors.