### PR TITLE
fix json_encode

### DIFF
--- a/integration_test/exqlite/all_test.exs
+++ b/integration_test/exqlite/all_test.exs
@@ -11,7 +11,8 @@ Code.require_file "#{ecto}/integration_test/cases/windows.exs", __DIR__
 Code.require_file "./ecto/interval.exs", __DIR__
 
 # we also added some fixes to their decimal precision tests
-# Code.require_file "./ecto/type.exs", __DIR__
+# we also added the :like_match_blob tag
+Code.require_file "./ecto/type.exs", __DIR__
 
 
 ecto_sql = Mix.Project.deps_paths()[:ecto_sql]

--- a/integration_test/exqlite/ecto/type.exs
+++ b/integration_test/exqlite/ecto/type.exs
@@ -5,6 +5,7 @@ defmodule Ecto.Integration.TypeTest do
   alias Ecto.Integration.TestRepo
   import Ecto.Query
 
+  @tag :onboarding
   test "primitive types" do
     integer  = 1
     float    = 0.1
@@ -103,6 +104,7 @@ defmodule Ecto.Integration.TypeTest do
     assert [^blob] = TestRepo.all(query)
   end
 
+  @tag :onboarding
   test "coalesce text type when value" do
     blob = <<0, 2>>
     default_blob = <<0, 1>>
@@ -256,6 +258,7 @@ defmodule Ecto.Integration.TypeTest do
     assert TestRepo.get!(Post, post.id).meta == %{"world" => "hello"}
   end
 
+  @tag :onboarding
   @tag :map_type
   test "embeds one" do
     item = %Item{price: 123, valid_at: ~D[2014-01-16]}
@@ -322,6 +325,7 @@ defmodule Ecto.Integration.TypeTest do
     assert TestRepo.one(from o in Order, select: o.items[0]["valid_at"]) == "2020-01-01"
   end
 
+  @tag :onboarding
   @tag :map_type
   @tag :map_type_schemaless
   test "embeds one with custom type" do
@@ -439,6 +443,7 @@ defmodule Ecto.Integration.TypeTest do
     assert Decimal.equal?(decimal, cost)
   end
 
+  @tag :onboarding
   @tag :decimal_type
   test "on coalesce with mixed types" do
     decimal = Decimal.new("1.0")

--- a/integration_test/exqlite/test_helper.exs
+++ b/integration_test/exqlite/test_helper.exs
@@ -94,6 +94,9 @@ ExUnit.start(
     # does not support using LIKE on BLOB types
     :like_match_blob,
 
+    # we are in the midst of onboarding these (i.e., fixing the bugs they point towards)
+    :onboarding,
+
     # we should be able to fully/correctly support these, but don't currently
     :with_conflict_target,
     :without_conflict_target,

--- a/lib/ecto/adapters/exqlite.ex
+++ b/lib/ecto/adapters/exqlite.ex
@@ -80,11 +80,6 @@ defmodule Ecto.Adapters.Exqlite do
   end
 
   @impl Ecto.Adapter
-  def loaders(:binary_id, type) do
-    [Ecto.UUID, type]
-  end
-
-  @impl Ecto.Adapter
   def loaders(:naive_datetime_usec, type) do
     [&Codec.datetime_decode/1, type]
   end
@@ -167,11 +162,6 @@ defmodule Ecto.Adapters.Exqlite do
   end
 
   @impl Ecto.Adapter
-  def dumpers(:binary_id, type) do
-    [type, Ecto.UUID]
-  end
-
-  @impl Ecto.Adapter
   def dumpers(:boolean, type) do
     [type, &Codec.bool_encode/1]
   end
@@ -203,6 +193,11 @@ defmodule Ecto.Adapters.Exqlite do
 
   @impl Ecto.Adapter
   def dumpers({:map, _}, type) do
+    [type, &Codec.json_encode/1]
+  end
+
+  @impl Ecto.Adapter
+  def dumpers(:map, type) do
     [type, &Codec.json_encode/1]
   end
 

--- a/lib/ecto/adapters/exqlite/connection.ex
+++ b/lib/ecto/adapters/exqlite/connection.ex
@@ -1639,6 +1639,5 @@ defmodule Ecto.Adapters.Exqlite.Connection do
   defp escape_json_key(value) when is_binary(value) do
     value
     |> escape_string()
-    |> :binary.replace("\"", "\\\"", [:global])
   end
 end

--- a/lib/ecto/adapters/exqlite/connection.ex
+++ b/lib/ecto/adapters/exqlite/connection.ex
@@ -1200,7 +1200,7 @@ defmodule Ecto.Adapters.Exqlite.Connection do
     path =
       Enum.map(path, fn
         binary when is_binary(binary) ->
-          [?., ?", escape_json_key(binary), ?"]
+          [?., escape_json_key(binary)]
 
         integer when is_integer(integer) ->
           "[#{integer}]"
@@ -1639,6 +1639,6 @@ defmodule Ecto.Adapters.Exqlite.Connection do
   defp escape_json_key(value) when is_binary(value) do
     value
     |> escape_string()
-    |> :binary.replace("\"", "\\\\\"", [:global])
+    |> :binary.replace("\"", "\\\"", [:global])
   end
 end

--- a/lib/ecto/adapters/exqlite/connection.ex
+++ b/lib/ecto/adapters/exqlite/connection.ex
@@ -1639,5 +1639,6 @@ defmodule Ecto.Adapters.Exqlite.Connection do
   defp escape_json_key(value) when is_binary(value) do
     value
     |> escape_string()
+    |> :binary.replace("\"", "\\\"", [:global])
   end
 end

--- a/test/ecto/adapters/exqlite/connection_test.exs
+++ b/test/ecto/adapters/exqlite/connection_test.exs
@@ -960,16 +960,16 @@ defmodule Ecto.Adapters.Exqlite.ConnectionTest do
     assert all(query) == ~s{SELECT json_extract(s0.meta, '$[0][1]') FROM schema AS s0}
 
     query = Schema |> select([s], json_extract_path(s.meta, ["a", "b"])) |> plan()
-    assert all(query) == ~s{SELECT json_extract(s0.meta, '$."a"."b"') FROM schema AS s0}
+    assert all(query) == ~s{SELECT json_extract(s0.meta, '$.a.b') FROM schema AS s0}
 
     query = Schema |> select([s], json_extract_path(s.meta, ["'a"])) |> plan()
-    assert all(query) == ~s{SELECT json_extract(s0.meta, '$."''a"') FROM schema AS s0}
+    assert all(query) == ~s{SELECT json_extract(s0.meta, '$.''a') FROM schema AS s0}
 
     query = Schema |> select([s], json_extract_path(s.meta, ["\"a"])) |> plan()
-    assert all(query) == ~s{SELECT json_extract(s0.meta, '$."\\\\"a"') FROM schema AS s0}
+    assert all(query) == ~s{SELECT json_extract(s0.meta, '$.\\"a') FROM schema AS s0}
 
     query = Schema |> select([s], s.meta["author"]["name"]) |> plan()
-    assert all(query) == ~s{SELECT json_extract(s0.meta, '$."author"."name"') FROM schema AS s0}
+    assert all(query) == ~s{SELECT json_extract(s0.meta, '$.author.name') FROM schema AS s0}
   end
 
   test "nested expressions" do

--- a/test/ecto/adapters/exqlite/connection_test.exs
+++ b/test/ecto/adapters/exqlite/connection_test.exs
@@ -966,7 +966,7 @@ defmodule Ecto.Adapters.Exqlite.ConnectionTest do
     assert all(query) == ~s{SELECT json_extract(s0.meta, '$.''a') FROM schema AS s0}
 
     query = Schema |> select([s], json_extract_path(s.meta, ["\"a"])) |> plan()
-    assert all(query) == ~s{SELECT json_extract(s0.meta, '$.\"a') FROM schema AS s0}
+    assert all(query) == ~s{SELECT json_extract(s0.meta, '$.\\"a') FROM schema AS s0}
 
     query = Schema |> select([s], s.meta["author"]["name"]) |> plan()
     assert all(query) == ~s{SELECT json_extract(s0.meta, '$.author.name') FROM schema AS s0}

--- a/test/ecto/adapters/exqlite/connection_test.exs
+++ b/test/ecto/adapters/exqlite/connection_test.exs
@@ -966,7 +966,7 @@ defmodule Ecto.Adapters.Exqlite.ConnectionTest do
     assert all(query) == ~s{SELECT json_extract(s0.meta, '$.''a') FROM schema AS s0}
 
     query = Schema |> select([s], json_extract_path(s.meta, ["\"a"])) |> plan()
-    assert all(query) == ~s{SELECT json_extract(s0.meta, '$.\\"a') FROM schema AS s0}
+    assert all(query) == ~s{SELECT json_extract(s0.meta, '$.\"a') FROM schema AS s0}
 
     query = Schema |> select([s], s.meta["author"]["name"]) |> plan()
     assert all(query) == ~s{SELECT json_extract(s0.meta, '$.author.name') FROM schema AS s0}


### PR DESCRIPTION
A couple of issues:

1. We were not encoding JSON for the `:map` type.
2. We were wrapping the various json keys used in lookup in double quotes, which is not necessary in SQLite
3. We were opting-in to a binary key that `Jason` would fail to encode

(2) manifests itself mainly here:
```
select json_extract('{ "a": 1, "\"b\"": 2 }', '$.a');
=> 1

select json_extract('{ "a": 1, "\"b\"": 2 }', '$."a"');
=> 1

select json_extract('{ "a": 1, "\"b\"": 2 }', '$.\"b\"');
=> 2

select json_extract('{ "a": 1, "\"b\"": 2 }', '$."\"b\""');
(no result)
```

That last row was causing us issues, and the solution was to simply not wrap with double quotes to avoid it. It may be a bug in SQLite, I think. I started a thread about it [here](https://sqlite.org/forum/forumpost/1f5263a98f).

Fixes #60 