### PR TITLE
Fix blob return from NIF

### DIFF
--- a/c_src/sqlite3_nif.c
+++ b/c_src/sqlite3_nif.c
@@ -392,14 +392,10 @@ make_cell(ErlNifEnv* env, sqlite3_stmt* statement, unsigned int i)
             return make_atom(env, "nil");
 
         case SQLITE_BLOB:
-            return enif_make_tuple2(
+            return make_binary(
                 env,
-                make_atom(env, "blob"),
-                make_binary(
-                    env,
-                    sqlite3_column_blob(statement, i),
-                    sqlite3_column_bytes(statement, i)
-                )
+                sqlite3_column_blob(statement, i),
+                sqlite3_column_bytes(statement, i)
             );
 
         case SQLITE_TEXT:

--- a/integration_test/exqlite/ecto/type.exs
+++ b/integration_test/exqlite/ecto/type.exs
@@ -104,7 +104,6 @@ defmodule Ecto.Integration.TypeTest do
     assert [^blob] = TestRepo.all(query)
   end
 
-  @tag :onboarding
   test "coalesce text type when value" do
     blob = <<0, 2>>
     default_blob = <<0, 1>>


### PR DESCRIPTION
We wrap blobs in a tuple when passing from Elixir to the NIF so the NIF can know which SQLite type to mark it as. However, when we return it we don't need that extra `:blob` key. In the Ecto case, we generally know the column and map according to that, and in the non-Ecto case this wrapping doesn't need to be exposed, as the client should know what to expect for the return result.

Specifically, this was causing an issue where we would return `{:blob, the_blob}` for `coalesce` queries, with no real way of unwrapping it in Elixir.

This is because for most `coalesce` queries, the type Ecto deems the return value as being is seemingly always `:any`.

See `deps/ecto/lib/ecto/query/planner.ex:1351`:
```
  defp collect_fields({:coalesce, _, [left, right]} = expr, fields, from, query, take, _keep_literals?) do
    {left_type, _, _} = collect_fields(left, fields, from, query, take, true)
    {right_type, _, _} = collect_fields(right, fields, from, query, take, true)

    type = if left_type == right_type, do: left_type, else: {:value, :any}
    {type, [expr | fields], from}
  end
```

And for `:any` types, Ecto never bothers calling any associated `loaders`.

See `deps/ecto/lib/ecto/repo/queryable.ex:376`:
```
  defp process([value | row], {:value, :any}, _from, _adapter) do
    {value, row}
  end
```

The alternative to this change would be to change Ecto itself in some way, making it so it always calls the loaders even for the `:any` case. But since we don't need the `:blob` tuple anyway, I went with this change.