### PR TITLE
onboard one of the embed tests

### DIFF
--- a/integration_test/exqlite/ecto/type.exs
+++ b/integration_test/exqlite/ecto/type.exs
@@ -257,7 +257,6 @@ defmodule Ecto.Integration.TypeTest do
     assert TestRepo.get!(Post, post.id).meta == %{"world" => "hello"}
   end
 
-  @tag :onboarding
   @tag :map_type
   test "embeds one" do
     item = %Item{price: 123, valid_at: ~D[2014-01-16]}

--- a/lib/ecto/adapters/exqlite.ex
+++ b/lib/ecto/adapters/exqlite.ex
@@ -110,11 +110,6 @@ defmodule Ecto.Adapters.Exqlite do
   end
 
   @impl Ecto.Adapter
-  def loaders({:embed, _} = type, _) do
-    [&Codec.json_decode/1, &Ecto.Type.embedded_load(type, &1, :json)]
-  end
-
-  @impl Ecto.Adapter
   def loaders({:map, _}, type) do
     [&Codec.json_decode/1, &Ecto.Type.embedded_load(type, &1, :json)]
   end
@@ -172,11 +167,6 @@ defmodule Ecto.Adapters.Exqlite do
   end
 
   @impl Ecto.Adapter
-  def dumpers({:embed, _} = type, _) do
-    [&Ecto.Type.embedded_dump(type, &1, :json)]
-  end
-
-  @impl Ecto.Adapter
   def dumpers(:time, type) do
     [type, &Codec.time_encode/1]
   end
@@ -193,7 +183,7 @@ defmodule Ecto.Adapters.Exqlite do
 
   @impl Ecto.Adapter
   def dumpers({:map, _}, type) do
-    [type, &Codec.json_encode/1]
+    [&Ecto.Type.embedded_dump(type, &1, :json), &Codec.json_encode/1]
   end
 
   @impl Ecto.Adapter


### PR DESCRIPTION
The other "embed with custom type" test I can't get working. Looks like something is happening in `Ecto.Repo.Queryable.execute/4` that is resulting in Ecto not associating any type information with a returned single column. :shrug: 

Get an error like:
```
  2) test embeds one with custom type (Ecto.Integration.TypeTest)
     integration_test/exqlite/ecto/type.exs:329
     match (=) failed
     code:  assert [%{"reference" => "EXAMPLE"}] = TestRepo.all(from(o in "orders", select: o.item))
     left:  [%{"reference" => "EXAMPLE"}]
     right: [
              "{\"id\":\"f288e439-9f68-45de-bbf2-56edaa7703ec\",\"price\":123,\"primary_color\":null,\"reference\":\"EXAMPLE\",\"secondary_colors\":[],\"user_id\":null,\"valid_at\":null}"
            ]
     stacktrace:
       integration_test/exqlite/ecto/type.exs:340: (test)

```

Which is indicating our loader is not called due to Ecto dropping the ball somewhere. Anyway, I'll save it for another day.