### PR TITLE
onboard transaction.exs suite, various transaction fixes

### DIFF
--- a/c_src/sqlite3_nif.c
+++ b/c_src/sqlite3_nif.c
@@ -572,7 +572,7 @@ exqlite_transaction_status(ErlNifEnv* env, int argc, const ERL_NIF_TERM argv[])
     int autocommit = sqlite3_get_autocommit(conn->db);
     return make_ok_tuple(
         env,
-        autocommit == 0 ? enif_make_atom(env, "transaction") : enif_make_atom(env, "idle"));
+        autocommit == 0 ? make_atom(env, "transaction") : make_atom(env, "idle"));
 }
 
 static void

--- a/c_src/sqlite3_nif.c
+++ b/c_src/sqlite3_nif.c
@@ -145,6 +145,7 @@ exqlite_close(ErlNifEnv* env, int argc, const ERL_NIF_TERM argv[])
     assert(env);
 
     connection_t* conn = NULL;
+    int rc = SQLITE_OK;
 
     if (argc != 1) {
         return enif_make_badarg(env);
@@ -154,7 +155,21 @@ exqlite_close(ErlNifEnv* env, int argc, const ERL_NIF_TERM argv[])
         return make_error_tuple(env, "invalid_connection");
     }
 
+    int autocommit = sqlite3_get_autocommit(conn->db);
+    if (autocommit == 0) {
+        rc = sqlite3_exec(conn->db, "ROLLBACK;", NULL, NULL, NULL);
+        if (rc != SQLITE_OK) {
+            return make_sqlite3_error_tuple(env, rc, conn->db);
+        }
+    }
+
+    // note: _v2 may not fully close the connection, hence why we check if 
+    // any transaction is open above, to make sure other connections aren't blocked. 
+    // v1 is guaranteed to close or error, but will return error if any
+    // unfinalized statements, which we likely have, as we rely on the destructors 
+    // to later run to clean those up 
     sqlite3_close_v2(conn->db);
+
     conn->db = NULL;
 
     return make_atom(env, "ok");
@@ -539,6 +554,27 @@ exqlite_last_insert_rowid(ErlNifEnv* env, int argc, const ERL_NIF_TERM argv[])
     return make_ok_tuple(env, enif_make_int64(env, last_rowid));
 }
 
+static ERL_NIF_TERM
+exqlite_transaction_status(ErlNifEnv* env, int argc, const ERL_NIF_TERM argv[])
+{
+    assert(env);
+
+    connection_t* conn = NULL;
+
+    if (argc != 1) {
+        return enif_make_badarg(env);
+    }
+
+    if (!enif_get_resource(env, argv[0], connection_type, (void**)&conn)) {
+        return make_error_tuple(env, "invalid_connection");
+    }
+
+    int autocommit = sqlite3_get_autocommit(conn->db);
+    return make_ok_tuple(
+        env,
+        autocommit == 0 ? enif_make_atom(env, "transaction") : enif_make_atom(env, "idle"));
+}
+
 static void
 connection_type_destructor(ErlNifEnv* env, void* arg)
 {
@@ -611,6 +647,7 @@ static ErlNifFunc nif_funcs[] = {
   {"step", 2, exqlite_step, ERL_NIF_DIRTY_JOB_IO_BOUND},
   {"columns", 2, exqlite_columns, ERL_NIF_DIRTY_JOB_IO_BOUND},
   {"last_insert_rowid", 1, exqlite_last_insert_rowid, ERL_NIF_DIRTY_JOB_IO_BOUND},
+  {"transaction_status", 1, exqlite_transaction_status, ERL_NIF_DIRTY_JOB_IO_BOUND},
 };
 
 ERL_NIF_INIT(Elixir.Exqlite.Sqlite3NIF, nif_funcs, on_load, NULL, NULL, NULL)

--- a/integration_test/exqlite/all_test.exs
+++ b/integration_test/exqlite/all_test.exs
@@ -22,7 +22,7 @@ Code.require_file "#{ecto_sql}/integration_test/sql/sandbox.exs", __DIR__
 Code.require_file "#{ecto_sql}/integration_test/sql/sql.exs", __DIR__
 Code.require_file "#{ecto_sql}/integration_test/sql/stream.exs", __DIR__
 Code.require_file "#{ecto_sql}/integration_test/sql/subquery.exs", __DIR__
-# Code.require_file "#{ecto_sql}/integration_test/sql/transaction.exs", __DIR__
+Code.require_file "#{ecto_sql}/integration_test/sql/transaction.exs", __DIR__
 
 # added :modify_column and :alter_foreign_key
 Code.require_file "./ecto_sql/migration.exs", __DIR__

--- a/lib/exqlite/sqlite3.ex
+++ b/lib/exqlite/sqlite3.ex
@@ -81,6 +81,9 @@ defmodule Exqlite.Sqlite3 do
   @spec last_insert_rowid(db()) :: {:ok, integer()}
   def last_insert_rowid(conn), do: Sqlite3NIF.last_insert_rowid(conn)
 
+  @spec transaction_status(db()) :: {:ok, :idle | :transaction}
+  def transaction_status(conn), do: Sqlite3NIF.transaction_status(conn)
+
   @doc """
   Causes the database connection to free as much memory as it can. This is
   useful if you are on a memory restricted system.

--- a/lib/exqlite/sqlite3_nif.ex
+++ b/lib/exqlite/sqlite3_nif.ex
@@ -43,5 +43,8 @@ defmodule Exqlite.Sqlite3NIF do
   @spec last_insert_rowid(db()) :: {:ok, integer()}
   def last_insert_rowid(_conn), do: :erlang.nif_error(:not_loaded)
 
+  @spec transaction_status(db()) :: {:ok, :idle | :transaction}
+  def transaction_status(_conn), do: :erlang.nif_error(:not_loaded)
+
   # TODO: add statement inspection tooling https://sqlite.org/c3ref/expanded_sql.html
 end


### PR DESCRIPTION
The main test that was failing was this one, which was subsequently blocking the other tests was:

```
    @tag :transaction_checkout_raises
    test "checkout raises on transaction attempt" do
      assert_raise DBConnection.ConnectionError, ~r"connection was checked out with status", fn ->
        PoolRepo.checkout(fn -> PoolRepo.query!("BEGIN") end)
      end
    end
```

We assume that all transaction-beginning statements go through our `handle_transaction` call which is not the case. Here we don't detect we begin a transaction and thus don't know we are in an active transaction at "checkin" time, hence why the error is not thrown.

The fix is to add a new `transaction_status` NIF call that uses http://www.sqlite.org/c3ref/get_autocommit.html to return the current transaction status, and wiring that up in the correct places.

The second issue was that `:disconnect` was not properly rolling back a transaction. This is because `sqlite3_close_v2` is not guaranteed to succeed, and indeed was going into a "zombie" state, as described at https://www.sqlite.org/c3ref/close.html . The fix for this was to make sure we atleast roll back any active transaction before doing this close logic, and then relying on the GC to clean the open prepared statements.

This closes #93 and likely also closes #58 .